### PR TITLE
Add bare functionality (Dockerfile + hash subcommand)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+.dockerignore
+target/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,3 +8,4 @@ edition = "2018"
 [dependencies]
 sha2 = "0.10.1"
 hex = "0.4.3"
+clap = { version = "3.0.13", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,3 +7,4 @@ edition = "2018"
 
 [dependencies]
 sha2 = "0.10.1"
+hex = "0.4.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,3 +6,4 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+sha2 = "0.10.1"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+## Builder image
+FROM rust:latest AS builder
+
+RUN rustup target add x86_64-unknown-linux-musl
+RUN apt update && apt install -y musl-tools musl-dev
+
+WORKDIR /src
+
+COPY ./ .
+
+RUN cargo build --target x86_64-unknown-linux-musl --release
+
+## Final image
+FROM scratch
+
+WORKDIR /src
+
+COPY --from=builder /src/target/x86_64-unknown-linux-musl/release/authenticator ./
+
+ENTRYPOINT ["./authenticator"]

--- a/README.md
+++ b/README.md
@@ -9,8 +9,18 @@ Clone this repository:
 git clone git@github.com:sguimmara/authenticator.git
 ```
 
-Build it using `cargo`
+Build it using `cargo`:
 
 ```
 cargo build
+cargo run -- <subcommand> [ARGS]
 ```
+
+Alternatively, you can build it using Docker :
+
+```
+docker build -t authenticator:example .
+docker run authenticator:example <subcommand> [ARGS]
+```
+
+> Note: the Docker image builds the binary against the musl libc (see https://musl.libc.org/)

--- a/authenticator.code-workspace
+++ b/authenticator.code-workspace
@@ -1,0 +1,10 @@
+{
+	"folders": [
+		{
+			"path": "."
+		}
+	],
+	"settings": {
+		"workspace.isHidden": true
+	}
+}

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -1,0 +1,30 @@
+use sha2::{Digest, Sha256};
+
+pub fn hash(text: &str) -> String {
+    let mut hasher = Sha256::new();
+
+    hasher.update(text);
+
+    let result = hasher.finalize();
+
+    let h = hex::encode(result);
+
+    return h;
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    pub fn hash_returns_correct_value() {
+        let text = "hello world";
+
+        let actual = hash(text);
+
+        assert_eq!(
+            actual,
+            "b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9"
+        )
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,5 @@
+mod core;
+
 fn main() {
     println!("Hello, world!");
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,24 @@
+use clap::{arg, App, AppSettings};
+
 mod core;
 
 fn main() {
-    println!("Hello, world!");
+    let app = clap::App::new("authenticator")
+        .bin_name("authenticator")
+        .setting(clap::AppSettings::SubcommandRequired)
+        .subcommand(
+            App::new("hash")
+                .about("return the SHA-256 hash of the supplied text")
+                .arg(arg!(<TEXT> "the text to"))
+                .setting(AppSettings::ArgRequiredElseHelp),
+        )
+        .get_matches();
+
+    match app.subcommand() {
+        Some(("hash", sub_matches)) => {
+            let text = sub_matches.value_of("TEXT").unwrap();
+            println!("SHA-256 of \"{}\": {}", text, core::hash(text));
+        }
+        _ => unreachable!(),
+    }
 }


### PR DESCRIPTION
This branch contains the bare functionality of the program :
* A `Dockerfile`
* The CLI definition with the `hash` subcommand, to hash a text in SHA-256.